### PR TITLE
refractor: replace instances of master branch with main

### DIFF
--- a/expansions.txt
+++ b/expansions.txt
@@ -222,7 +222,7 @@ Nefarious Plastic Mannequins
 Nefarious Pomegranate Magnate
 Nefarious Punk Monk
 Nefariously Programmed Mecha
-Nefariously Pushing Master
+Nefariously Pushing Main
 Negating Past Mistakes
 Negatively Proportional Model
 Negatory. Postpone Mission.
@@ -348,7 +348,7 @@ Never Publish Malarkey
 Never Pummel Muskoxen
 Never Punch Manticores
 Never Push Mistakes
-Never Push to Master
+Never Push to Main
 Neverending Package Mountain
 Neverending Perpetual Motion
 Neverending Pile of Messages


### PR DESCRIPTION
## Description

In an attempt to make the npm expansions more inclusive for all minorities I replaced all instances of the infamous "master" branch with "main". The term master is out of favor in the computing world and beyond, thats why even Github decided that starting October 1st 2020 all new GitHub repositories will create a default branch named main.

### Type of change

- [x] Refractor (non-breaking change which cleans up code)